### PR TITLE
Chaincode object should be initialized outside the load function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 .project
 node_modules


### PR DESCRIPTION
The load function stores network peer data, registers users with security, and load chaincode.  The intent is for users to be able to use this function for convenience or break out and perform these steps themselves, ie. when they wanted to control which user(s) gets registered against each pear.  This won't work because the chaincode object that these sub-functions use is only initialized in the load function, causing errors to be thrown.  Simply initializing the object outside of the load function and reinitializing it on ever load function call resolves these issues.