### PR TITLE
fix enrollId error

### DIFF
--- a/test/cb_readyTest.js
+++ b/test/cb_readyTest.js
@@ -27,7 +27,9 @@ var options = {
 	// For simplicity, I chose the first user on the list provided.
 	users: [{
 		"username": "user_type0_52737ec3c6",
-		"secret": "4841d68d27" 
+		"secret": "4841d68d27",
+		"enrollId":"user_type0_52737ec3c6",
+		"enrollSecret":"4841d68d27"		
 	}] }, 
 
 	// The chaincode version being tested here is the one deployed in Marbles2.


### PR DESCRIPTION
in the helper.js, user.enrollId is need.

//==================================================================
//filter_users() - return only client level enrollId - [1=client, 2=nvp, 4=vp, 8=auditor accurate as of 2/18]
//==================================================================
module.exports.filter_users = function(users){										//this is only needed in a permissioned network
	var valid_users = [];
	for(var i = 0; i < users.length; i++) {
		if(users[i].enrollId.indexOf('user_type1') === 0){							//type should be 1 for client
			valid_users.push(users[i]);
		}
	}
	return valid_users;
};